### PR TITLE
Get `urlencode()` in a Python 2 compatible way.

### DIFF
--- a/liqui.py
+++ b/liqui.py
@@ -2,6 +2,10 @@ import hmac
 import hashlib
 from time import time
 from urllib.parse import urlencode
+try:
+    from urllib.parse import urlencode
+except ImportError:
+    from urllib import urlencode
 
 import requests
 


### PR DESCRIPTION
I just added a conditional import so that the code works in Python 2 as well. I'm not sure that your aim is to explicitly support Python 3 only but in case it wasn't, I hope this helps.